### PR TITLE
Remove Unidecode due to licensing issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pypinyin
 jieba
 # english
 eng_to_ipa
-unidecode
+anyascii
 inflect
 # japanese
 # if pyopenjtalk fail to download open_jtalk_dic_utf_8-1.11.tar.gz, manually download and unzip the file below 

--- a/text/english.py
+++ b/text/english.py
@@ -18,7 +18,7 @@ hyperparameter. Some cleaners are English-specific. You'll typically want to use
 
 import re
 import inflect
-from unidecode import unidecode
+from anyascii import anyascii
 import eng_to_ipa as ipa
 _inflect = inflect.engine()
 _comma_number_re = re.compile(r'([0-9][0-9\,]+[0-9])')
@@ -158,7 +158,7 @@ def mark_dark_l(text):
 
 
 def english_to_ipa(text):
-    text = unidecode(text).lower()
+    text = anyascii(text).lower()
     text = expand_abbreviations(text)
     text = normalize_numbers(text)
     phonemes = ipa.convert(text)

--- a/text/japanese.py
+++ b/text/japanese.py
@@ -1,5 +1,5 @@
 import re
-from unidecode import unidecode
+from anyascii import anyascii
 import pyopenjtalk
 
 
@@ -108,7 +108,7 @@ def japanese_to_romaji_with_accent(text):
                 elif a2 == 1 and a2_next == 2:
                     text += '↑'
         if i < len(marks):
-            text += unidecode(marks[i]).replace(' ', '')
+            text += anyascii(marks[i]).replace(' ', '')
     return text
 
 


### PR DESCRIPTION
Hi,
Thanks for releasing StableTTS!
This PR replaces the GPL-licensed `unidecode` library with the ISC-licensed alternative `anyascii`.
Thanks!